### PR TITLE
removed redundant dash on backtitle option

### DIFF
--- a/winbind_cui.sh
+++ b/winbind_cui.sh
@@ -381,7 +381,7 @@ break
 done
 ) |
 whiptail --title "Server Integration" \
-         ---backtitle "$backtitle" \
+         --backtitle "$backtitle" \
          --gauge "Wait for the servers to be integrated and synchronized ...." 10 60 0 
 
 


### PR DESCRIPTION
Removed redundant dash, which caused errormessage.